### PR TITLE
Access and mutation methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,7 @@ impl<T: BitBlock, const N: usize> TinyBitSet<T, N> {
     /// # Panics
     ///
     /// Panics if `bit >= Self::CAPACITY`.
-    pub fn flip(&mut self, bit: usize) {
+    pub fn toggle(&mut self, bit: usize) {
         self.blocks[bit / T::BITS] ^= T::LSB << (bit % T::BITS);
     }
 
@@ -171,8 +171,8 @@ impl<T: BitBlock, const N: usize> TinyBitSet<T, N> {
     ///
     /// Panics if `bit >= Self::CAPACITY`.
     #[must_use]
-    pub fn flipped(mut self, bit: usize) -> Self {
-        self.flip(bit);
+    pub fn toggled(mut self, bit: usize) -> Self {
+        self.toggle(bit);
         self
     }
 
@@ -504,34 +504,34 @@ mod tests {
     }
 
     #[test]
-    fn flip() {
+    fn toggle() {
         let mut bs = TestBitSet::EMPTY;
-        bs.flip(9);
+        bs.toggle(9);
         assert_eq!(TestBitSet::from([0b0000_0000, 0b0000_0010]), bs);
-        bs.flip(5);
+        bs.toggle(5);
         assert_eq!(TestBitSet::from([0b0010_0000, 0b0000_0010]), bs);
-        bs.flip(5);
+        bs.toggle(5);
         assert_eq!(TestBitSet::from([0b0000_0000, 0b0000_0010]), bs);
     }
 
     #[test]
     #[should_panic]
-    fn flip_out_of_range() {
-        TestBitSet::new().flip(16);
+    fn toggle_out_of_range() {
+        TestBitSet::new().toggle(16);
     }
 
     #[test]
-    fn flipped() {
+    fn toggled() {
         let bs = TestBitSet::singleton(11);
-        assert_eq!(TestBitSet::EMPTY, bs.flipped(11));
-        assert_eq!(bs, bs.flipped(11).flipped(11));
-        assert_eq!(bs.inserted(5), bs.flipped(5));
+        assert_eq!(TestBitSet::EMPTY, bs.toggled(11));
+        assert_eq!(bs, bs.toggled(11).toggled(11));
+        assert_eq!(bs.inserted(5), bs.toggled(5));
     }
 
     #[test]
     #[should_panic]
-    fn flipped_out_of_range() {
-        let _ = TestBitSet::new().flipped(16);
+    fn toggled_out_of_range() {
+        let _ = TestBitSet::new().toggled(16);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@ impl<T: BitBlock, const N: usize> TinyBitSet<T, N> {
     ///
     /// # Panics
     ///
-    /// Panics if `bit` is greater than or equal to [`Self::CAPACITY`].
+    /// Panics if `bit >= Self::CAPACITY`.
     pub fn singleton(bit: usize) -> Self {
         let mut blocks = [T::EMPTY; N];
         blocks[bit / T::BITS] = T::LSB << (bit % T::BITS);
@@ -122,7 +122,7 @@ impl<T: BitBlock, const N: usize> TinyBitSet<T, N> {
     ///
     /// # Panics
     ///
-    /// Panics if the bit index is greater than or equal to [`Self::CAPACITY`].
+    /// Panics if `bit >= Self::CAPACITY`.
     pub fn insert(&mut self, bit: usize) {
         self.blocks[bit / T::BITS] |= T::LSB << (bit % T::BITS);
     }
@@ -131,7 +131,7 @@ impl<T: BitBlock, const N: usize> TinyBitSet<T, N> {
     ///
     /// # Panics
     ///
-    /// Panics if the bit index is greater than or equal to [`Self::CAPACITY`].
+    /// Panics if `bit >= Self::CAPACITY`.
     pub fn remove(&mut self, bit: usize) {
         self.blocks[bit / T::BITS] &= !(T::LSB << (bit % T::BITS));
     }
@@ -140,7 +140,7 @@ impl<T: BitBlock, const N: usize> TinyBitSet<T, N> {
     ///
     /// # Panics
     ///
-    /// Panics if the bit index is greater than or equal to [`Self::CAPACITY`].
+    /// Panics if `bit >= Self::CAPACITY`.
     pub fn flip(&mut self, bit: usize) {
         self.blocks[bit / T::BITS] ^= T::LSB << (bit % T::BITS);
     }
@@ -149,7 +149,7 @@ impl<T: BitBlock, const N: usize> TinyBitSet<T, N> {
     ///
     /// # Panics
     ///
-    /// Panics if the bit index is greater than or equal to [`Self::CAPACITY`].
+    /// Panics if `bit >= Self::CAPACITY`.
     pub fn assign(&mut self, bit: usize, value: bool) {
         if value {
             self.insert(bit);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,19 @@ impl<T: BitBlock, const N: usize> TinyBitSet<T, N> {
     pub const fn capacity(self) -> usize {
         Self::CAPACITY
     }
+
+    /// Counts the number of bits that are set.
+    pub fn len(self) -> usize {
+        self.blocks
+            .into_iter()
+            .map(|block| block.count_ones() as usize)
+            .sum()
+    }
+
+    /// Returns whether no bits are set.
+    pub fn is_empty(self) -> bool {
+        self.blocks.iter().all(|&block| block == T::EMPTY)
+    }
 }
 
 impl<T: BitBlock, const N: usize> Default for TinyBitSet<T, N> {
@@ -328,6 +341,21 @@ mod tests {
     #[should_panic]
     fn singleton_out_of_range() {
         let _ = TestBitSet::singleton(16);
+    }
+
+    #[test]
+    fn len() {
+        assert_eq!(0, TestBitSet::EMPTY.len());
+        assert_eq!(1, TestBitSet::singleton(5).len());
+        assert_eq!(6, TestBitSet::from([0b1000_0001, 0b0011_1100]).len());
+    }
+
+    #[test]
+    fn is_empty() {
+        assert!(TestBitSet::EMPTY.is_empty());
+        assert!(!TestBitSet::singleton(5).is_empty());
+        assert!(!TestBitSet::from([0b1000_0001, 0b0011_1100]).is_empty());
+        assert!(TestBitSet::from([0b0000_0000, 0b0000_0000]).is_empty());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,24 @@ impl<T: BitBlock, const N: usize> TinyBitSet<T, N> {
         blocks: [T::ALL; N],
     };
 
+    /// Creates an empty bitset.
+    ///
+    /// Equivalent to [`Self::EMPTY`].
+    pub const fn new() -> Self {
+        Self::EMPTY
+    }
+
+    /// Creates a bitset with exactly one bit set.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `bit` is greater than or equal to [`Self::CAPACITY`].
+    pub fn singleton(bit: usize) -> Self {
+        let mut blocks = [T::EMPTY; N];
+        blocks[bit / T::BITS] = T::LSB << (bit % T::BITS);
+        Self::from(blocks)
+    }
+
     /// Number of bits in the bitset.
     ///
     /// Equivalent to [`Self::CAPACITY`].
@@ -287,6 +305,29 @@ mod tests {
             TestBitSet::from([0b1111_1111, 0b1111_1111]),
             TestBitSet::ALL
         );
+    }
+
+    #[test]
+    fn new() {
+        assert_eq!(TestBitSet::EMPTY, TestBitSet::new());
+    }
+
+    #[test]
+    fn singleton() {
+        let singleton0 = TestBitSet::singleton(0);
+        assert!(singleton0[0]);
+        assert!(!singleton0[1]);
+        assert_eq!(TestBitSet::from([0b0000_0001, 0b0000_0000]), singleton0);
+        assert_eq!(
+            TestBitSet::from([0b0000_0000, 0b0000_0100]),
+            TestBitSet::singleton(10)
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn singleton_out_of_range() {
+        let _ = TestBitSet::singleton(16);
     }
 
     #[test]


### PR DESCRIPTION
Adds:

- `new()` and `singleton(bit)`
- `len()` and `is_empty()`, counting the number of set bits (using the interpretation of a bitset as a set of numbers)
- Mutation methods, each with an in-place and a copying version:
  - `insert(bit)`/`inserted(bit)`
  - `remove(bit)`/`removed(bit)`
  - `toggle(bit)`/`toggled(bit)`
  - `assign(bit, value)`/`assigned(bit, value)`

These names lean more towards the interpretation of bitsets as sets of numbers. The alternative would be using the array-of-bools interpretation with names like `set`, `unset`, `flip`, `count_ones`,  `count_zeros`, etc. I'm not sure what is preferable TBH.

Includes changes from the previous open PRs.